### PR TITLE
After* functions should return error

### DIFF
--- a/bond.go
+++ b/bond.go
@@ -27,7 +27,7 @@ type HasBeforeCreate interface {
 }
 
 type HasAfterCreate interface {
-	AfterCreate(Session)
+	AfterCreate(Session) error
 }
 
 type HasBeforeUpdate interface {
@@ -35,7 +35,7 @@ type HasBeforeUpdate interface {
 }
 
 type HasAfterUpdate interface {
-	AfterUpdate(Session)
+	AfterUpdate(Session) error
 }
 
 type HasBeforeDelete interface {
@@ -43,5 +43,5 @@ type HasBeforeDelete interface {
 }
 
 type HasAfterDelete interface {
-	AfterDelete(Session)
+	AfterDelete(Session) error
 }

--- a/bond_test.go
+++ b/bond_test.go
@@ -45,9 +45,9 @@ func (a *Account) CollectionName() string {
 	return DB.Account.Name()
 }
 
-func (a Account) AfterCreate(sess bond.Session) {
+func (a Account) AfterCreate(sess bond.Session) error {
 	message := fmt.Sprintf("Account %q was created.", a.Name)
-	sess.Save(&Log{Message: message})
+	return sess.Save(&Log{Message: message})
 }
 
 func (a *Account) BeforeDelete() error {
@@ -63,9 +63,9 @@ type User struct {
 	Username  string `db:"username"`
 }
 
-func (u User) AfterCreate(sess bond.Session) {
+func (u User) AfterCreate(sess bond.Session) error {
 	message := fmt.Sprintf("User %q was created.", u.Username)
-	sess.Save(&Log{Message: message})
+	return sess.Save(&Log{Message: message})
 }
 
 func (u *User) CollectionName() string {

--- a/store.go
+++ b/store.go
@@ -50,7 +50,9 @@ func (s *store) Append(item interface{}) (interface{}, error) {
 	}
 
 	if m, ok := item.(HasAfterCreate); ok {
-		m.AfterCreate(s.session)
+		if err := m.AfterCreate(s.session); err != nil {
+			return nil, err
+		}
 	}
 
 	return id, nil
@@ -92,7 +94,9 @@ func (s *store) Save(item interface{}) error {
 		pkField.Set(reflect.ValueOf(id))
 
 		if m, ok := item.(HasAfterCreate); ok {
-			m.AfterCreate(s.session)
+			if err := m.AfterCreate(s.session); err != nil {
+				return err
+			}
 		}
 
 	} else {
@@ -112,7 +116,9 @@ func (s *store) Save(item interface{}) error {
 		}
 
 		if m, ok := item.(HasAfterUpdate); ok {
-			m.AfterUpdate(s.session)
+			if err := m.AfterUpdate(s.session); err != nil {
+				return err
+			}
 		}
 
 	}
@@ -146,7 +152,9 @@ func (s *store) Delete(item interface{}) error {
 	}
 
 	if m, ok := item.(HasAfterDelete); ok {
-		m.AfterDelete(s.session)
+		if err := m.AfterDelete(s.session); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Since the support for transactions was added operation can be cancelled (and possibly rolled back) by both Before\* and After\* functions of the store. 
Cancellation/rollback/error in Before\* functions is returned as error
Cancellation/rollback/error in After\* functions can't be returned as they currently return nothing
This pull request fixes that.
