### PR TITLE
Picks up already started tx in NewTransaction and continues in it

### DIFF
--- a/session.go
+++ b/session.go
@@ -37,12 +37,15 @@ func Open(adapter string, url db.ConnectionURL) (Session, error) {
 }
 
 // NewTransaction creates and returns a session that runs within a transaction
-// block.
+// block or continues to run in a previously started transaction block.
 func (s *session) NewTransaction() (Session, error) {
-
-	tx, err := s.Database.Transaction()
-	if err != nil {
-		return nil, err
+	tx, ok := s.Database.(db.Tx)
+	if !ok {
+		var err error
+		tx, err = s.Database.Transaction()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	sess := &session{


### PR DESCRIPTION
This is better than checking if you're already in a tx block in
everything that needs to run in transaction - nested tx errors suck
