### PR TITLE
Add result.And() - implements db.Result of upper/db.v2

### DIFF
--- a/result.go
+++ b/result.go
@@ -55,6 +55,14 @@ func (r *result) Where(terms ...interface{}) db.Result {
 	return r
 }
 
+func (r *result) And(terms ...interface{}) db.Result {
+	if r.args.where == nil {
+		return r.Where(terms...)
+	}
+	*r.args.where = append(*r.args.where, terms...)
+	return r
+}
+
 func (r *result) Group(fields ...interface{}) db.Result {
 	r.args.group = &fields
 	return r


### PR DESCRIPTION
Fixes upper.io/db.v2:
```
# github.com/pressly/api/vendor/upper.io/bond
vendor/upper.io/bond/result.go:35: cannot use r (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
vendor/upper.io/bond/result.go:40: cannot use r (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
vendor/upper.io/bond/result.go:45: cannot use r (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
vendor/upper.io/bond/result.go:50: cannot use r (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
vendor/upper.io/bond/result.go:55: cannot use r (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
vendor/upper.io/bond/result.go:60: cannot use r (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
vendor/upper.io/bond/session.go:109: cannot use result (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
vendor/upper.io/bond/store.go:36: cannot use result (type *result) as type db.Result in return argument:
	*result does not implement db.Result (missing And method)
```